### PR TITLE
Allow to create subset of default elements

### DIFF
--- a/oemoflex/preprocessing.py
+++ b/oemoflex/preprocessing.py
@@ -62,10 +62,15 @@ def create_default_elements(
     ----------
     dir : str (dir path)
         target directory where to put the prepared CSVs
+
     components_file : str (file path)
         CSV where to read the components from
+
     component_attrs_dir : str (dir path)
         CSV where to read the components' attributes from
+
+    select_components : list
+        List of default elements to create
 
     Returns
     -------

--- a/oemoflex/preprocessing.py
+++ b/oemoflex/preprocessing.py
@@ -50,7 +50,8 @@ module_path = os.path.dirname(os.path.abspath(__file__))
 def create_default_elements(
         dir,
         components_file='components.csv',
-        component_attrs_dir='component_attrs'
+        component_attrs_dir='component_attrs',
+        select_components=None,
 ):
     r"""
     Prepares oemoef.tabluar input CSV files:
@@ -75,9 +76,16 @@ def create_default_elements(
     # TODO Better put this as another field into the components.csv as well?
     component_attrs_dir = os.path.join(module_path, component_attrs_dir)
 
-    components = pd.read_csv(components_file)
+    components = pd.read_csv(components_file).name.values
 
-    for component in components.name.values:
+    if select_components is not None:
+        no_default = set(select_components).difference(set(components))
+
+        assert not no_default, f"Selected components {no_default} are not in components."
+
+        components = [c for c in components if c in select_components]
+
+    for component in components:
         component_attrs_file = os.path.join(component_attrs_dir, component + '.csv')
 
         try:


### PR DESCRIPTION
In the use cases of experiment 1, not all technologies appear in every use case.

This PR allows to switch on only selected elements. Per default, all element files are created. If 'select_components' is passed, only the selection is created.

TODO: 
* [x] adapt docstring