### PR TITLE
Remove Flexmex1 prefix from timeseries file names

### DIFF
--- a/oemoflex/postprocessing.py
+++ b/oemoflex/postprocessing.py
@@ -1021,7 +1021,7 @@ def save_flexmex_timeseries(sequences_by_tech, usecase, model, year, dir):
                     dir,
                     subfolder,
                     subsubfolder,
-                    '_'.join(['FlexMex1', usecase, model, region, year]) + '.csv'
+                    '_'.join([usecase, model, region, year]) + '.csv'
                 )
 
                 single_column = df_var_value[column]


### PR DESCRIPTION
The timeseries results' filenames start with an unnecessary duplication which also does not conform to the project's convention. This PR removes the prefix.