### PR TITLE
Adapt path definition in join script

### DIFF
--- a/experiment_1/scripts/join_results.py
+++ b/experiment_1/scripts/join_results.py
@@ -4,12 +4,11 @@ import sys
 
 import pandas as pd
 
-from oemoflex.helpers import setup_experiment_paths
+from oemoflex.helpers import get_experiment_paths
 
 
 # Get paths
-basepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-exp_paths = setup_experiment_paths('', basepath)
+exp_paths = get_experiment_paths()
 
 exp_paths.results_comparison = os.path.join(exp_paths.results_comparison, 'oemof')
 


### PR DESCRIPTION
A minor fix: The path definition of the join_results script has to be adapted because the path defining functions have been adapted.