### PR TITLE
Save timeseries headers

### DIFF
--- a/oemoflex/postprocessing.py
+++ b/oemoflex/postprocessing.py
@@ -1026,7 +1026,9 @@ def save_flexmex_timeseries(sequences_by_tech, usecase, model, year, dir):
 
                 single_column = df_var_value[column]
                 single_column = single_column.reset_index(drop=True)
-                single_column.to_csv(filename, header=False)
+                single_column.name = 'value'
+                single_column.index.name = 'timeindex'
+                single_column.to_csv(filename, header=True)
 
     delete_empty_subdirs(dir)
 


### PR DESCRIPTION
Until now, timeseries were not saved with a header. This causes problems with the comparison tool that plots timeseries of all models in FlexMex. This PR makes sure that the timeseries are saved with a header: timeindex, value. This allows the timeseries to be correctly processed and appear in the plots.