### PR TITLE
Adapt links to new parametrization in oemof.tabular

### DIFF
--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -1,7 +1,7 @@
 from oemof.solph import sequence, Bus, Source, Sink, Transformer, Flow, Investment
 from oemof.solph.components import GenericStorage, ExtractionTurbineCHP
 
-from oemof.tabular.facades import Facade, TYPEMAP
+from oemof.tabular.facades import Facade, Link, TYPEMAP
 
 
 class Source(Source):  # pylint: disable=E0102
@@ -43,6 +43,11 @@ class Facade(Facade):  # pylint: disable=E0102
         """
         if self.expandable is True:
             return None
+
+        if isinstance(self, Link):
+            return {
+                "from_to": self.from_to_capacity,
+                "to_from": self.to_from_capacity}
 
         if isinstance(self, AsymmetricStorage):
             return {

--- a/oemoflex/model_structure/component_attrs/electricity-transmission.csv
+++ b/oemoflex/model_structure/component_attrs/electricity-transmission.csv
@@ -6,6 +6,7 @@ carrier,str,n/a,electricity,,Energy carrier
 tech,str,n/a,transmission,,Technology
 from_bus,str,n/a,,-electricity,Bus where link starts
 to_bus,str,n/a,,-electricity,Bus where link ends
-capacity,float,MW,n/a,,Net transfer capacity
+from_to_capacity,float,MW,n/a,,Net transfer capacity in forward direction
+to_from_capacity,float,MW,n/a,,Net transfer capacity in backward direction
 capacity_cost,float,Eur/MW,n/a,,Annualized costs of capacity expansion
 loss,float,unitless,n/a,,Transmission losses

--- a/oemoflex/preprocessing.py
+++ b/oemoflex/preprocessing.py
@@ -580,7 +580,9 @@ def update_link(data_preprocessed_path, scalars):
         scalars,
         'Transmission_Capacity_Electricity_Grid')
 
-    link['capacity'] = transmission_capacity
+    link['from_to_capacity'] = transmission_capacity
+
+    link['to_from_capacity'] = transmission_capacity
 
     # Calculation with pandas series
     link['loss'] = (


### PR DESCRIPTION
Without our notice, oemof.tabular has introduced directed transmission capacites. This lead to the attribute `capacity` not being processed, leading to unconstrained transmission between regions. This PR adapts introduces the new attributes `from_to_capacity` and `to_from_capacity`.