### PR TITLE
Fix Travis build and linters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 # commands to run tests 
 script:
   - flake8
-  - pylint */*.py
+  - pylint oemoflex tests
   - pytest --cov=oemoflex
 #jobs:
 #  include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ python:
 #  apt:
 #    update: true
 
+addons:
+ apt:
+   packages:
+     - coinor-cbc
+
 # command to install dependencies
 install:
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 # commands to run tests 
 script:
   - flake8
-  - pylint oemoflex tests
+  - pylint oemoflex tests/*.py
   - pytest --cov=oemoflex
 #jobs:
 #  include:

--- a/experiment_1/scripts/FlexMex1_10/optimization.py
+++ b/experiment_1/scripts/FlexMex1_10/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_2a/optimization.py
+++ b/experiment_1/scripts/FlexMex1_2a/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_2a/preprocessing.py
+++ b/experiment_1/scripts/FlexMex1_2a/preprocessing.py
@@ -37,8 +37,8 @@ def main():
     # one for 'FlexMex1' and one for 'FlexMex1UC2'
     # Drop the second one, only keep "Energy_SlackCost_Electricity" for use case 2b
     rows_to_drop = scalars.loc[
-          (scalars['Parameter'] == 'Energy_SlackCost_Electricity')
-          & (scalars['Scenario'] == 'FlexMex1'), :].index
+        (scalars['Parameter'] == 'Energy_SlackCost_Electricity')
+        & (scalars['Scenario'] == 'FlexMex1'), :].index
 
     scalars = scalars.drop(rows_to_drop)
 

--- a/experiment_1/scripts/FlexMex1_2b/optimization.py
+++ b/experiment_1/scripts/FlexMex1_2b/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_2b/preprocessing.py
+++ b/experiment_1/scripts/FlexMex1_2b/preprocessing.py
@@ -37,8 +37,8 @@ def main():
     # one for 'FlexMex1' and one for 'FlexMex1UC2'
     # Drop the second one, only keep "Energy_SlackCost_Electricity" for use case 2b
     rows_to_drop = scalars.loc[
-          (scalars['Parameter'] == 'Energy_SlackCost_Electricity')
-          & (scalars['Scenario'] == 'FlexMex1'), :].index
+        (scalars['Parameter'] == 'Energy_SlackCost_Electricity')
+        & (scalars['Scenario'] == 'FlexMex1'), :].index
 
     scalars = scalars.drop(rows_to_drop)
 

--- a/experiment_1/scripts/FlexMex1_2c/optimization.py
+++ b/experiment_1/scripts/FlexMex1_2c/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_2c/preprocessing.py
+++ b/experiment_1/scripts/FlexMex1_2c/preprocessing.py
@@ -38,8 +38,8 @@ def main():
     # one for 'FlexMex1' and one for 'FlexMex1UC2'
     # Drop the second one, only keep "Energy_SlackCost_Electricity" for use case 2b
     rows_to_drop = scalars.loc[
-          (scalars['Parameter'] == 'Energy_SlackCost_Electricity')
-          & (scalars['Scenario'] == 'FlexMex1'), :].index
+        (scalars['Parameter'] == 'Energy_SlackCost_Electricity')
+        & (scalars['Scenario'] == 'FlexMex1'), :].index
 
     scalars = scalars.drop(rows_to_drop)
 

--- a/experiment_1/scripts/FlexMex1_2d/optimization.py
+++ b/experiment_1/scripts/FlexMex1_2d/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_2d/preprocessing.py
+++ b/experiment_1/scripts/FlexMex1_2d/preprocessing.py
@@ -37,8 +37,8 @@ def main():
     # one for 'FlexMex1' and one for 'FlexMex1UC2'
     # Drop the second one, only keep "Energy_SlackCost_Electricity" for use case 2b
     rows_to_drop = scalars.loc[
-          (scalars['Parameter'] == 'Energy_SlackCost_Electricity')
-          & (scalars['Scenario'] == 'FlexMex1'), :].index
+        (scalars['Parameter'] == 'Energy_SlackCost_Electricity')
+        & (scalars['Scenario'] == 'FlexMex1'), :].index
 
     scalars = scalars.drop(rows_to_drop)
 

--- a/experiment_1/scripts/FlexMex1_3/optimization.py
+++ b/experiment_1/scripts/FlexMex1_3/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_3/preprocessing.py
+++ b/experiment_1/scripts/FlexMex1_3/preprocessing.py
@@ -33,14 +33,14 @@ def main():
     scalars = scalars.loc[scalars['Scenario'].isin([name, 'FlexMex1', 'ALL']), :]
 
     components = [
-            'electricity-shortage',
-            'electricity-curtailment',
-            'electricity-demand',
-            'hydro-reservoir',
-            'wind-offshore',
-            'wind-onshore',
-            'solar-pv',
-        ]
+        'electricity-shortage',
+        'electricity-curtailment',
+        'electricity-demand',
+        'hydro-reservoir',
+        'wind-offshore',
+        'wind-onshore',
+        'solar-pv',
+    ]
 
     # Prepare oemof.tabular input CSV files
     create_default_elements(

--- a/experiment_1/scripts/FlexMex1_4a/optimization.py
+++ b/experiment_1/scripts/FlexMex1_4a/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_4b/optimization.py
+++ b/experiment_1/scripts/FlexMex1_4b/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_4c/optimization.py
+++ b/experiment_1/scripts/FlexMex1_4c/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_4d/optimization.py
+++ b/experiment_1/scripts/FlexMex1_4d/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_4e/optimization.py
+++ b/experiment_1/scripts/FlexMex1_4e/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_4e/preprocessing.py
+++ b/experiment_1/scripts/FlexMex1_4e/preprocessing.py
@@ -36,21 +36,21 @@ def main():
     scalars = scalars.loc[scalars['Scenario'].isin([name, 'FlexMex1', 'ALL']), :]
 
     components = [
-                'electricity-shortage',
-                'electricity-curtailment',
-                'electricity-demand',
-                'heat-demand',
-                'heat-excess',
-                'heat-shortage',
-                'wind-offshore',
-                'wind-onshore',
-                'solar-pv',
-                'ch4-extchp',
-                'ch4-boiler-large',
-                'electricity-pth',
-                'electricity-heatpump-large',
-                'heat-storage-large',
-            ]
+        'electricity-shortage',
+        'electricity-curtailment',
+        'electricity-demand',
+        'heat-demand',
+        'heat-excess',
+        'heat-shortage',
+        'wind-offshore',
+        'wind-onshore',
+        'solar-pv',
+        'ch4-extchp',
+        'ch4-boiler-large',
+        'electricity-pth',
+        'electricity-heatpump-large',
+        'heat-storage-large',
+    ]
 
     # Prepare oemof.tabular input CSV files
     create_default_elements(

--- a/experiment_1/scripts/FlexMex1_5/optimization.py
+++ b/experiment_1/scripts/FlexMex1_5/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/FlexMex1_7b/optimization.py
+++ b/experiment_1/scripts/FlexMex1_7b/optimization.py
@@ -1,5 +1,3 @@
-"""
-"""
 from oemof.tools.logger import define_logging
 
 from oemoflex.helpers import setup_experiment_paths

--- a/experiment_1/scripts/compare_scalars.py
+++ b/experiment_1/scripts/compare_scalars.py
@@ -44,8 +44,11 @@ def filter_by_usecase(sc_in, usecase):
     return sc
 
 
-def prepare_scalars(model, usecase, index=['UseCase', 'Region', 'Year', 'Parameter']):
+def prepare_scalars(model, usecase, index=None):
     r""" Load scalars, filter for usecase, sort and set name of pd.Series. """
+
+    if index is None:
+        index = ['UseCase', 'Region', 'Year', 'Parameter']
 
     sc = load_scalars(model)
 

--- a/experiment_1/scripts/compare_scalars.py
+++ b/experiment_1/scripts/compare_scalars.py
@@ -34,17 +34,17 @@ def load_scalars(model, base_path=comparison_path):
     return sc
 
 
-def filter_by_usecase(sc_in, usecase):
+def filter_by_usecase(sc_in, uc):
     r""" Filter scalars for UseCase """
 
     sc = sc_in.copy()  # copy to avoid unintended overwriting
 
-    sc = sc.loc[sc['UseCase'] == usecase]
+    sc = sc.loc[sc['UseCase'] == uc]
 
     return sc
 
 
-def prepare_scalars(model, usecase, index=None):
+def prepare_scalars(model, uc, index=None):
     r""" Load scalars, filter for usecase, sort and set name of pd.Series. """
 
     if index is None:
@@ -52,7 +52,7 @@ def prepare_scalars(model, usecase, index=None):
 
     sc = load_scalars(model)
 
-    sc = filter_by_usecase(sc, usecase)
+    sc = filter_by_usecase(sc, uc)
 
     sc.set_index(index, inplace=True)  # set index to the columns that are common
 
@@ -85,15 +85,15 @@ def calculate_diff_and_relative_deviation(a, b):
 def average_per_region(diff_in):
     r""" Takes the regional average of a pd.DataFrame. """
 
-    mean_diff = diff_in.copy()
+    mean_region = diff_in.copy()
 
-    by = list(mean_diff.index.names)
+    by = list(mean_region.index.names)
 
     by.remove('Region')  # groupby all index levels apart from 'Region'
 
-    mean_diff = mean_diff.groupby(by=by).mean()
+    mean_region = mean_region.groupby(by=by).mean()
 
-    return mean_diff
+    return mean_region
 
 
 for usecase in usecases:

--- a/experiment_1/scripts/join_results.py
+++ b/experiment_1/scripts/join_results.py
@@ -25,7 +25,7 @@ if os.path.exists(exp_paths.results_comparison):
 
 os.makedirs(exp_paths.results_comparison)
 
-experiments = [
+usecases = [
     'FlexMex1_2a',
     'FlexMex1_2b',
     'FlexMex1_2c',
@@ -43,15 +43,15 @@ experiments = [
 
 
 def join_scalars(experiments):
-    all_scalars = []
+    scalars = []
     for subdir in experiments:
         scalar = pd.read_csv(
             os.path.join('../005_results_postprocessed', subdir, 'Scalars.csv'), index_col=[0])
-        all_scalars.append(scalar)
+        scalars.append(scalar)
 
-    all_scalars = pd.concat(all_scalars)
+    scalars = pd.concat(scalars)
 
-    return all_scalars
+    return scalars
 
 
 def copy_timeseries(experiments, fro, to):
@@ -65,7 +65,7 @@ def copy_timeseries(experiments, fro, to):
         ))
 
 
-all_scalars = join_scalars(experiments)
+all_scalars = join_scalars(usecases)
 all_scalars.to_csv('../006_results_comparison/oemof/Scalars.csv')
 
-copy_timeseries(experiments, exp_paths.results_postprocessed, exp_paths.results_comparison)
+copy_timeseries(usecases, exp_paths.results_postprocessed, exp_paths.results_comparison)

--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -1,10 +1,12 @@
-from oemof.solph import sequence, Bus, Source, Sink, Transformer, Flow, Investment
+from oemof import solph
+from oemof.solph import sequence, Bus, Sink, Flow, Investment
 from oemof.solph.components import GenericStorage, ExtractionTurbineCHP
 
-from oemof.tabular.facades import Facade, Link, TYPEMAP
+from oemof.tabular import facades
+from oemof.tabular.facades import Link, TYPEMAP
 
 
-class Source(Source):  # pylint: disable=E0102
+class Source(solph.Source):
     r"""
     Supplement Source with carrier and tech properties to work with labeling in postprocessing
 
@@ -19,7 +21,7 @@ class Source(Source):  # pylint: disable=E0102
         self.tech = kwargs.get('tech', None)
 
 
-class Transformer(Transformer):  # pylint: disable=E0102
+class Transformer(solph.Transformer):
     r"""
     Supplement Transformer with carrier and tech properties to work with labeling in postprocessing
 
@@ -35,7 +37,7 @@ class Transformer(Transformer):  # pylint: disable=E0102
         self.tech = kwargs.get('tech', None)
 
 
-class Facade(Facade):  # pylint: disable=E0102
+class Facade(facades.Facade):
 
     def _nominal_value(self):
         """ Returns None if self.expandable ist True otherwise it returns

--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -711,7 +711,8 @@ class ExtractionTurbine(ExtractionTurbineCHP, Facade):  # pylint: disable=too-ma
 TYPEMAP.update(
     {
         "asymmetric storage": AsymmetricStorage,
-        "reservoir": ReservoirWithPump, "bev": Bev,
+        "reservoir": ReservoirWithPump,
+        "bev": Bev,
         "extraction": ExtractionTurbine,
     }
 )

--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -1,10 +1,16 @@
-from oemof.solph import sequence, Bus, Source, Sink, Transformer, Flow, Investment
+from oemof.solph import (
+    sequence, Bus,
+    Source as solph_Source,
+    Sink,
+    Transformer as solph_Transformer,
+    Flow, Investment
+    )
 from oemof.solph.components import GenericStorage, ExtractionTurbineCHP
 
-from oemof.tabular.facades import Facade, Link, TYPEMAP
+from oemof.tabular.facades import Facade as solph_Facade, Link, TYPEMAP as solph_TYPEMAP
 
 
-class Source(Source):  # pylint: disable=E0102
+class Source(solph_Source):
     r"""
     Supplement Source with carrier and tech properties to work with labeling in postprocessing
 
@@ -19,7 +25,7 @@ class Source(Source):  # pylint: disable=E0102
         self.tech = kwargs.get('tech', None)
 
 
-class Transformer(Transformer):  # pylint: disable=E0102
+class Transformer(solph_Transformer):
     r"""
     Supplement Transformer with carrier and tech properties to work with labeling in postprocessing
 
@@ -35,7 +41,7 @@ class Transformer(Transformer):  # pylint: disable=E0102
         self.tech = kwargs.get('tech', None)
 
 
-class Facade(Facade):  # pylint: disable=E0102
+class Facade(solph_Facade):
 
     def _nominal_value(self):
         """ Returns None if self.expandable ist True otherwise it returns
@@ -706,7 +712,7 @@ class ExtractionTurbine(ExtractionTurbineCHP, Facade):
         )
 
 
-TYPEMAP.update(
+TYPEMAP = solph_TYPEMAP.update(
     {
         "asymmetric storage": AsymmetricStorage,
         "reservoir": ReservoirWithPump, "bev": Bev,

--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -1,16 +1,10 @@
-from oemof.solph import (
-    sequence, Bus,
-    Source as solph_Source,
-    Sink,
-    Transformer as solph_Transformer,
-    Flow, Investment
-    )
+from oemof.solph import sequence, Bus, Source, Sink, Transformer, Flow, Investment
 from oemof.solph.components import GenericStorage, ExtractionTurbineCHP
 
-from oemof.tabular.facades import Facade as solph_Facade, Link, TYPEMAP as solph_TYPEMAP
+from oemof.tabular.facades import Facade, Link, TYPEMAP
 
 
-class Source(solph_Source):
+class Source(Source):  # pylint: disable=E0102
     r"""
     Supplement Source with carrier and tech properties to work with labeling in postprocessing
 
@@ -25,7 +19,7 @@ class Source(solph_Source):
         self.tech = kwargs.get('tech', None)
 
 
-class Transformer(solph_Transformer):
+class Transformer(Transformer):  # pylint: disable=E0102
     r"""
     Supplement Transformer with carrier and tech properties to work with labeling in postprocessing
 
@@ -41,7 +35,7 @@ class Transformer(solph_Transformer):
         self.tech = kwargs.get('tech', None)
 
 
-class Facade(solph_Facade):
+class Facade(Facade):  # pylint: disable=E0102
 
     def _nominal_value(self):
         """ Returns None if self.expandable ist True otherwise it returns
@@ -712,7 +706,7 @@ class ExtractionTurbine(ExtractionTurbineCHP, Facade):  # pylint: disable=too-ma
         )
 
 
-TYPEMAP = solph_TYPEMAP.update(
+TYPEMAP.update(
     {
         "asymmetric storage": AsymmetricStorage,
         "reservoir": ReservoirWithPump, "bev": Bev,

--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -538,7 +538,7 @@ class ReservoirWithPump(GenericStorage, Facade):
         self.subnodes = (inflow, internal_bus, pump)
 
 
-class ExtractionTurbine(ExtractionTurbineCHP, Facade):
+class ExtractionTurbine(ExtractionTurbineCHP, Facade):  # pylint: disable=too-many-ancestors
     r""" Combined Heat and Power (extraction) unit with one input and
     two outputs.
 

--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -655,9 +655,9 @@ class ExtractionTurbine(ExtractionTurbineCHP, Facade):
 
         self.capacity = kwargs.get("capacity")
 
-        self.fuel_capacity = self.capacity / self.condensing_efficiency
-
         self.condensing_efficiency = sequence(self.condensing_efficiency)
+
+        self.fuel_capacity = self.capacity / self.condensing_efficiency
 
         self.marginal_cost = kwargs.get("marginal_cost", 0)
 

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,7 @@ setup(
         'oemof.tabular',
         'pyyaml',
         'addict',
+        'Pyomo==5.6.7',
+        'PyUtilib==5.7.2'
     ],
 )


### PR DESCRIPTION
Fixes #104: a long dragged-along error in Travis tests (fixes #87), makes linters happy, and fixes #51. The aim is to have a clean Travis test and to be able to rely on it during further development.

* [x] #87
* [x] #51 (partly)
* [ ] DeprecationWarning for imp in distutils ([link](https://travis-ci.org/github/modex-flexmex/oemo-flex/builds/747443815#L604-L609)) - ~~can we ignore that?~~ moved to #132
* [x] R0901: Too many ancestors (8/7) (too-many-ancestors) ([link](https://travis-ci.org/github/modex-flexmex/oemo-flex/builds/747443815#L585)) - ignored for the moment - other ideas?
* [x] `tests/__init__.py` missing