### PR TITLE
Rename heatpump profile

### DIFF
--- a/flexmex_config/mapping-input-timeseries.yml
+++ b/flexmex_config/mapping-input-timeseries.yml
@@ -30,15 +30,13 @@ hydro-reservoir:
 
 electricity-heatpump-small:
   profiles:
-    cop:
+    efficiency:
       input-path: OtherProfiles/COP
-      output-name: efficiency
 
 electricity-heatpump-large:
   profiles:
-    cop:
+    efficiency:
       input-path: OtherProfiles/COP
-      output-name: efficiency
 
 electricity-bev:
   profiles:

--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -657,7 +657,7 @@ class ExtractionTurbine(ExtractionTurbineCHP, Facade):  # pylint: disable=too-ma
 
         self.capacity = kwargs.get("capacity")
 
-        self.fuel_capacity = self.capacity / self.condensing_efficiency
+        self.fuel_capacity = self.capacity / self.condensing_efficiency  # noqa: E501  # pylint: disable=access-member-before-definition  # done with kwargs.update()
 
         self.condensing_efficiency = sequence(self.condensing_efficiency)
 

--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -657,9 +657,9 @@ class ExtractionTurbine(ExtractionTurbineCHP, Facade):  # pylint: disable=too-ma
 
         self.capacity = kwargs.get("capacity")
 
-        self.condensing_efficiency = sequence(self.condensing_efficiency)
-
         self.fuel_capacity = self.capacity / self.condensing_efficiency
+
+        self.condensing_efficiency = sequence(self.condensing_efficiency)
 
         self.marginal_cost = kwargs.get("marginal_cost", 0)
 

--- a/oemoflex/model_structure/component_attrs/electricity-heatpump.csv
+++ b/oemoflex/model_structure/component_attrs/electricity-heatpump.csv
@@ -7,6 +7,6 @@ tech,str,n/a,heatpump,,Technology
 from_bus,str,n/a,,-electricity,The bus this component is connected to
 to_bus,str,n/a,,-heat,The bus this component is connected to
 capacity,float,MW,n/a,,Installed capacity
-efficiency,str,,,-cop-profile,Coefficient of performance
+efficiency,str,,,-efficiency-profile,Coefficient of performance
 marginal_cost,float,Eur/MWh,n/a,,Marginal cost
 output_parameters,dict,n/a,{},,Optional parameters passed to oemof-solph's output flow

--- a/oemoflex/preprocessing.py
+++ b/oemoflex/preprocessing.py
@@ -1318,14 +1318,9 @@ def create_profiles(exp_path, select_components):
                     recalc = recalculation_functions[function_name]
                     profile_df = recalc(profile_df)
 
-                try:
-                    output_filename_base = profile['output-name']
-                except KeyError:
-                    output_filename_base = profile_name
-
                 profile_df.to_csv(
                     os.path.join(
                         exp_path.data_preprocessed,
                         sequences_dir,
-                        output_filename_base + profile_file_suffix + '.csv')
+                        profile_name + profile_file_suffix + '.csv')
                 )


### PR DESCRIPTION
This solves #126: Drop different names for the timeseries read (cop) and the timeseries given to the model (efficiency) for the COP profile of 'heatpump'.

* [x] Rename the profile
* [x] Drop functionality in create_profiles()?

YAML structure can't be made easier (drop "input-path"), since we still have to distinguish one more attribute for each profile: "apply-function"