### PR TITLE
Fix scenario yaml files

### DIFF
--- a/scenarios/2c.yml
+++ b/scenarios/2c.yml
@@ -1,4 +1,4 @@
-scenario: FlexMex1_2a
+scenario: FlexMex1_2c
 
 year: 2050
 
@@ -6,16 +6,16 @@ components:
   electricity-shortage:
   electricity-curtailment:
   electricity-demand:
+  electricity-liion_battery:
+    expandable: True
+    greenfield: True
   wind-offshore:
   wind-onshore:
   solar-pv:
   uranium-nuclear-st:
     expandable: True
     greenfield: True
-  ch4-gt:
-    expandable: True
-    greenfield: True
-  
+
 scenario_select:
   - FlexMex1
   - ALL

--- a/scenarios/2c.yml
+++ b/scenarios/2c.yml
@@ -6,16 +6,16 @@ components:
   electricity-shortage:
   electricity-curtailment:
   electricity-demand:
+  electricity-liion_battery:
+    expandable: True
+    greenfield: True
   wind-offshore:
   wind-onshore:
   solar-pv:
   uranium-nuclear-st:
     expandable: True
     greenfield: True
-  ch4-gt:
-    expandable: True
-    greenfield: True
-  
+
 scenario_select:
   - FlexMex1
   - ALL

--- a/scenarios/2c.yml
+++ b/scenarios/2c.yml
@@ -6,16 +6,16 @@ components:
   electricity-shortage:
   electricity-curtailment:
   electricity-demand:
-  electricity-liion_battery:
-    expandable: True
-    greenfield: True
   wind-offshore:
   wind-onshore:
   solar-pv:
   uranium-nuclear-st:
     expandable: True
     greenfield: True
-
+  ch4-gt:
+    expandable: True
+    greenfield: True
+  
 scenario_select:
   - FlexMex1
   - ALL

--- a/scenarios/2d.yml
+++ b/scenarios/2d.yml
@@ -12,8 +12,10 @@ components:
   uranium-nuclear-st:
     expandable: True
     greenfield: True
-  electricity-transmission:
-
+  ch4-gt:
+    expandable: True
+    greenfield: True
+  
 scenario_select:
   - FlexMex1
   - ALL

--- a/scenarios/2d.yml
+++ b/scenarios/2d.yml
@@ -1,4 +1,4 @@
-scenario: FlexMex1_2a
+scenario: FlexMex1_2d
 
 year: 2050
 
@@ -12,10 +12,8 @@ components:
   uranium-nuclear-st:
     expandable: True
     greenfield: True
-  ch4-gt:
-    expandable: True
-    greenfield: True
-  
+  electricity-transmission:
+
 scenario_select:
   - FlexMex1
   - ALL

--- a/scenarios/2d.yml
+++ b/scenarios/2d.yml
@@ -12,10 +12,8 @@ components:
   uranium-nuclear-st:
     expandable: True
     greenfield: True
-  ch4-gt:
-    expandable: True
-    greenfield: True
-  
+  electricity-transmission:
+
 scenario_select:
   - FlexMex1
   - ALL

--- a/scenarios/5.yml
+++ b/scenarios/5.yml
@@ -13,6 +13,7 @@ components:
   heat-storage-small:
   heat-demand:
   heat-shortage:
+  ch4-gt:
 
 scenario_select:
   - FlexMex1

--- a/scenarios/5.yml
+++ b/scenarios/5.yml
@@ -13,7 +13,6 @@ components:
   heat-storage-small:
   heat-demand:
   heat-shortage:
-  ch4-gt:
 
 scenario_select:
   - FlexMex1

--- a/scenarios/7b.yml
+++ b/scenarios/7b.yml
@@ -10,6 +10,7 @@ components:
   wind-onshore:
   solar-pv:
   electricity-bev:
+  ch4-gt:
   
 scenario_select:
   - FlexMex1

--- a/scenarios/7b.yml
+++ b/scenarios/7b.yml
@@ -10,8 +10,7 @@ components:
   wind-onshore:
   solar-pv:
   electricity-bev:
-  ch4-gt:
-
+  
 scenario_select:
   - FlexMex1
   - ALL

--- a/scenarios/7b.yml
+++ b/scenarios/7b.yml
@@ -10,7 +10,6 @@ components:
   wind-onshore:
   solar-pv:
   electricity-bev:
-  ch4-gt:
   
 scenario_select:
   - FlexMex1

--- a/scenarios/7b.yml
+++ b/scenarios/7b.yml
@@ -10,7 +10,8 @@ components:
   wind-onshore:
   solar-pv:
   electricity-bev:
-  
+  ch4-gt:
+
 scenario_select:
   - FlexMex1
   - ALL


### PR DESCRIPTION
When testing #143 with the scenarios from FlexMex1 I found differences in some of the scenario yaml files (introduced with #136):
* scenario names in 2c, 2d (typo)
* wrong component lists in 2c, 2d, 5, 7b

I derived the correct versions from the preprocessing script files in 0f3212ad.