### PR TITLE
Fixes/large heatpump constant cop

### DIFF
--- a/flexmex_config/mapping-input-timeseries.yml
+++ b/flexmex_config/mapping-input-timeseries.yml
@@ -33,11 +33,6 @@ electricity-heatpump-small:
     efficiency:
       input-path: OtherProfiles/COP
 
-electricity-heatpump-large:
-  profiles:
-    efficiency:
-      input-path: OtherProfiles/COP
-
 electricity-bev:
   profiles:
     drive_power:

--- a/oemoflex/model_structure/foreign_keys.yml
+++ b/oemoflex/model_structure/foreign_keys.yml
@@ -42,7 +42,6 @@
 ]
 
 'efficiency': [
-    'electricity-heatpump-large',
     'electricity-heatpump-small',
 ]
 

--- a/oemoflex/parametrization_scalars.py
+++ b/oemoflex/parametrization_scalars.py
@@ -251,6 +251,10 @@ def update_electricity_heatpump_large(component_df, scalars):
         scalars, 'EnergyConversion_Capacity_Heat_ElectricityHeat_Large'
     )
 
+    component_df['efficiency'] = get_parameter_values(
+        scalars, 'EnergyConversion_COP_Heat_ElectricityHeat_Large'
+    )
+
     component_df['marginal_cost'] = get_parameter_values(
         scalars, 'EnergyConversion_VarOM_Heat_ElectricityHeat_Large') * 1e-3  # Eur/GWh to Eur/MWh
 


### PR DESCRIPTION
This PR sets a constant COP on the large-scale heatpumps in use case 4e. These heatpumps are assumed to have a heat source in the ground/sewage water and thus are modeled with a constant cop throughout the year.